### PR TITLE
Address "Memory" substitution problem

### DIFF
--- a/extract-tmam-metrics.py
+++ b/extract-tmam-metrics.py
@@ -189,7 +189,7 @@ def fixup(form, ebs_mode):
     form = re.sub(r"\bCLKS\b", "CPU_CLK_UNHALTED.THREAD", form)
     form = form.replace("_PS", "")
     form = form.replace("\b1==1\b", "1")
-    form = form.replace("Memory", "1" if args.memory else "0")
+    form = form.replace("#Memory == 1", "1" if args.memory else "0")
     form = re.sub(r'([A-Z0-9_.]+):c(\d+)', r'cpu@\1\\,cmask\\=\2@', form)
     form = form.replace("#(", "(") # XXX hack, shouldn't be needed
 

--- a/uncore_csv_json.py
+++ b/uncore_csv_json.py
@@ -88,10 +88,6 @@ def update(j):
     for k in list(j.keys()):
         if j[k] in ("0x0", "0x00", "0X00", "null", "", "0", None, "tbd", "TBD", "na"):
             del j[k]
-    if "BriefDescription" in j:
-        j["BriefDescription"] = str(j["BriefDescription"].encode("ascii", errors="ignore"))
-    if "PublicDescription" in j:
-        j["PublicDescription"] = str(j["PublicDescription"].encode("ascii", errors="ignore"))
     return j
 
 jl = []


### PR DESCRIPTION
Substituting #Memory can end up replacing in #Memory_Bound_Fraction
creating #0_Bound_Fraction (or #1...). This will then result in a
KeyError. Be more specific in the pattern to replace from TMA
Metrics to avoid the problem.