### PR TITLE
Only encode ASCII in C strings

### DIFF
--- a/perfjson.py
+++ b/perfjson.py
@@ -46,6 +46,8 @@ def cleanjf(jf):
             del jf[ind]
         if jf[ind]["EventName"].startswith("OFFCORE_RESPONSE_0"):
             jf[ind]["EventName"] = jf[ind]["EventName"].replace("OFFCORE_RESPONSE_0", "OFFCORE_RESPONSE")
+        for k, v in jf[ind].items():
+            jf[ind][k] = ''.join([c if ord(c) < 128 else '' for c in v])
 
 def fix_names(j):
     if "Description" in j and "BriefDescription" not in j:


### PR DESCRIPTION
01.org json files like icelakex_core_v1.06.json contain non-ASCII
characters that python3 encodes with \u. These encodings fail when
compiling with clang, for example:

tools/perf/pmu-events/pmu-events.c:54310:79: error: universal character name refers to a control character
        .desc = "Retired load instructions with remote Intel\u00c2\u00ae Optane\u00e2\u0084\u00a2 DC persistent memory as the data source where the data request missed all caches  Supports address when precise (Precise event)",

Rather than try to encode these characters, just remove them.