### PR TITLE
Fix print statement

### DIFF
--- a/csv-field.py
+++ b/csv-field.py
@@ -51,4 +51,4 @@ for j in c:
                 print(j[f])
         except KeyError:
             print("?")
-    print
+    print()


### PR DESCRIPTION
In `csv-field.csv`, pylint shows this warning in line 54:
> Statement seems to have no effect (pointless-statement)

This is because `print` is a function in python3, so we need to add parentheses.
```
>>> print  # no effect
<built-in function print>
>>> print()  # prints a new line

>>>
```