### PR TITLE
Latest fixes as were used to post to LKML

### DIFF
--- a/download_and_gen.py
+++ b/download_and_gen.py
@@ -229,8 +229,9 @@ class Mapfile:
             mapfile = csv.reader(mapfile_csv_lines)
             first_row = True
             for l in mapfile:
-                if len(l) == 6:
-                    l.append("")
+                while len(l) < 7:
+                    # Fix missing columns.
+                    l.append('')
                 family_model, version, path, event_type, core_type, native_model_id, core_role_name = l
                 if first_row:
                     assert family_model == 'Family-model'
@@ -247,8 +248,15 @@ class Mapfile:
                 url = base_url + path
 
                 # Bug fixes:
-                if shortname == 'SNR' and event_type == 'uncore' and 'experimental' in path:
-                    event_type = 'uncore experimental'
+                if shortname == 'ADL' and event_type == 'core':
+                    # ADL GenuineIntel-6-BE only has atom cores and so
+                    # they don't set event_type to 'hybridcore' but
+                    # 'core' leading to ADL having multiple core
+                    # paths. Avoid this by setting the type back to
+                    # atom.
+                    assert 'gracemont' in path
+                    event_type = 'atom'
+                    core_role_name = 'Atom'
 
                 # Workarounds:
                 if event_type == 'hybridcore':

--- a/download_and_gen.py
+++ b/download_and_gen.py
@@ -140,26 +140,7 @@ class Model:
                     outfile=outfile)
 
         # Additional metrics
-        broken_extra_metrics = {
-            'HSX': [
-                # Missing event 'c'.
-                'uncore_frequency',
-                # Missing event 'e'.
-                'llc_data_read_demand_plus_prefetch_miss_latency',
-                'llc_data_read_demand_plus_prefetch_miss_latency_for_local_requests',
-                'llc_data_read_demand_plus_prefetch_miss_latency_for_remote_requests',
-            ],
-            'ICX': [
-                # Missing event EXE_ACTIVITY.EXE_BOUND_0_PORTS
-                'tma_ports_utilization_percent',
-            ],
-            'SKX': [
-                # Missing cha/unc_cha_tor_occupancy.ia_miss/
-                'llc_data_read_demand_plus_prefetch_miss_latency',
-                'llc_data_read_demand_plus_prefetch_miss_latency_for_local_requests',
-                'llc_data_read_demand_plus_prefetch_miss_latency_for_remote_requests',
-            ],
-        }
+        broken_extra_metrics = {}
         if 'extra metrics' in self.files:
             with urllib.request.urlopen(
                     self.files['extra metrics']) as extra_metrics_json:
@@ -171,10 +152,12 @@ class Model:
                             'MetricName'].lower() in broken_extra_metrics[
                                 self.shortname]:
                         continue
-                    metrics = [
-                        x for x in metrics if x['MetricName'].lower() !=
-                        extra_metric['MetricName'].lower()
-                    ]
+                    if any(extra_metric['MetricName'].lower() == x['MetricName'].lower() for x in metrics):
+                        # Prefer existing metrics over those in extra
+                        # metrics as the existing metrics may be
+                        # written in terms of each other and have
+                        # consistent units.
+                        continue
                     metrics.append(extra_metric)
                 outfile = open(metrics_file, 'w', encoding='ascii')
                 outfile.write(

--- a/extract-tma-metrics.py
+++ b/extract-tma-metrics.py
@@ -246,12 +246,14 @@ def extract_tma_metrics(csvfile: TextIO, cpu: str, extrajson: TextIO,
     csvf = csv.reader(csvfile)
 
     class PerfMetric:
-       def  __init__(self, name: str, form: str, desc: str, groups: str, locate: str):
+       def  __init__(self, name: str, form: str, desc: str, groups: str,
+                     locate: str, scale_unit: Optional[str] = None):
            self.name = name
            self.form = form
            self.desc = desc
            self.groups = groups
            self.locate = locate
+           self.scale_unit = scale_unit
 
     # All the metrics read from the CSV file.
     info : Sequence[PerfMetric] = []
@@ -333,7 +335,8 @@ def extract_tma_metrics(csvfile: TextIO, cpu: str, extrajson: TextIO,
                     tma_metric_name = f'tma_{metric_name.lower()}'
                     info.append(PerfMetric(
                         tma_metric_name, form,
-                        field('Metric Description'), groups, locate_with()
+                        field('Metric Description'), groups, locate_with(),
+                        '100%'
                     ))
                     infoname[metric_name] = form
                     tma_metric_names[metric_name] = tma_metric_name
@@ -536,7 +539,7 @@ def extract_tma_metrics(csvfile: TextIO, cpu: str, extrajson: TextIO,
             form = fixup(form)
             return form
 
-        def save_form(name, group, form, desc, locate, extra=''):
+        def save_form(name, group, form, desc, locate, scale_unit, extra=''):
             if form == '':
                 return
             # Make 'TmaL1' group names more consistent with the 'tma_'
@@ -593,10 +596,13 @@ def extract_tma_metrics(csvfile: TextIO, cpu: str, extrajson: TextIO,
             if unit:
                 j['Unit'] = unit
 
+            if scale_unit:
+                j['ScaleUnit'] = scale_unit
+
             jo.append(j)
 
         form = resolve_all(form, cpu)
-        save_form(i.name, i.groups, form, i.desc, i.locate)
+        save_form(i.name, i.groups, form, i.desc, i.locate, i.scale_unit)
 
     if 'Socket_CLKS' in infoname:
         form = 'Socket_CLKS / #num_dies / duration_time / 1000000000'

--- a/extract-tma-metrics.py
+++ b/extract-tma-metrics.py
@@ -602,6 +602,14 @@ def extract_tma_metrics(csvfile: TextIO, cpu: str, extrajson: TextIO,
             jo.append(j)
 
         form = resolve_all(form, cpu, expand_metrics=False)
+        needs_slots = 'topdown\-' in form and 'SLOTS' not in form
+        if needs_slots:
+            # topdown events must always be grouped with a
+            # TOPDOWN.SLOTS event. Detect when this is missing in a
+            # metric and insert a dummy value. Metrics using other
+            # metrics with topdown events will get a TOPDOWN.SLOTS
+            # event from them.
+            form = f'{form} + 0*SLOTS'
         save_form(i.name, i.groups, form, i.desc, i.locate, i.scale_unit)
 
     if 'Socket_CLKS' in infoname:

--- a/extract-tma-metrics.py
+++ b/extract-tma-metrics.py
@@ -379,7 +379,7 @@ def extract_tma_metrics(csvfile: TextIO, cpu: str, extrajson: TextIO,
             if i.name in groups:
                 i.groups = groups[i.name]
 
-        def resolve_all(form: str, cpu: str):
+        def resolve_all(form: str, cpu: str, expand_metrics: bool):
 
             def fixup(form: str):
                 def update_fix(x: str) -> str:
@@ -493,7 +493,7 @@ def extract_tma_metrics(csvfile: TextIO, cpu: str, extrajson: TextIO,
                 return bracket(child)
 
             def resolve_info(v: str):
-                if v in ignore:
+                if v in ignore or (expand_metrics and v in infoname):
                     # If metric will be ignored in the output it must
                     # be expanded.
                     return bracket(fixup(infoname[v]))
@@ -601,12 +601,12 @@ def extract_tma_metrics(csvfile: TextIO, cpu: str, extrajson: TextIO,
 
             jo.append(j)
 
-        form = resolve_all(form, cpu)
+        form = resolve_all(form, cpu, expand_metrics=False)
         save_form(i.name, i.groups, form, i.desc, i.locate, i.scale_unit)
 
     if 'Socket_CLKS' in infoname:
         form = 'Socket_CLKS / #num_dies / duration_time / 1000000000'
-        form = check_expr(resolve_all(form, cpu))
+        form = check_expr(resolve_all(form, cpu, expand_metrics=False))
         if form:
             je.append({
                 'MetricName': 'UNCORE_FREQ',

--- a/uncore_csv_json.py
+++ b/uncore_csv_json.py
@@ -35,7 +35,7 @@ import copy
 import argparse
 import itertools
 import re
-from typing import TextIO
+from typing import (Dict, Optional, TextIO)
 
 repl_events = {
     "UNC_M_CLOCKTICKS": "UNC_M_DCLOCKTICKS"
@@ -84,12 +84,14 @@ def update(j):
             del j[k]
     return j
 
-def uncore_csv_json(csvfile: TextIO, jsonfile: TextIO, extrajsonfile: TextIO, targetdir: str, all_events: bool, verbose: bool):
+def uncore_csv_json(csvfile: TextIO, jsonfile: TextIO,
+                    extrajsonfile: Optional[TextIO],
+                    targetdir: str, all_events: bool, verbose: bool):
     verboseprint = print if verbose else lambda *a, **k: None
     events = read_events(jsonfile)
     events2 = read_events(extrajsonfile) if extrajsonfile else None
 
-    jl = []
+    jl : list[Dict[str, str]] = []
     added = set()
     c = csv.reader(csvfile)
     for l in c:
@@ -217,8 +219,8 @@ def uncore_csv_json(csvfile: TextIO, jsonfile: TextIO, extrajsonfile: TextIO, ta
 
     for j in jl:
         if "UMask" in j.keys() and "UMaskExt" in j.keys():
-            str = j["UMask"][2:]
-            j["UMask"] = j["UMaskExt"] + str
+            jstr = j["UMask"][2:]
+            j["UMask"] = j["UMaskExt"] + jstr
         if "FILTER_VALUE" in j.keys() and j["Filter"] == "Filter1":
             j["Filter"] = "config1=" + j["FILTER_VALUE"]
             del j["FILTER_VALUE"]
@@ -275,7 +277,7 @@ def uncore_csv_json(csvfile: TextIO, jsonfile: TextIO, extrajsonfile: TextIO, ta
         return j["Topic"]
 
     for topic, iter in itertools.groupby(sorted(jl, key=get_topic), key=get_topic):
-        events = list(iter)
+        events : list[Dict[str, str]] = list(iter)
         for j in events:
             del j["Topic"]
         verboseprint("generating", topic)


### PR DESCRIPTION
LKML post: https://lore.kernel.org/linux-perf-users/20221001060636.2661983-1-irogers@google.com/

Remove a workaround for SPR fixed in mapfile.csv but add in a new ADL one.
Topdown metrics are out of 100%, so add a ScaleUnit.
If topdown events are used, ensure the metric has a slots event to avoid a broken group (tested on Tigerlake).
Prefer generated metrics over ones from github as the units will match.
Fix some typing, code hygiene issues.