### PR TITLE
Fetch events from GitHub

### DIFF
--- a/download_and_gen.py
+++ b/download_and_gen.py
@@ -226,8 +226,18 @@ class Mapfile:
                     assert core_role_name == 'Core Role Name'
                     first_row = False
                     continue
-                shortname = re.sub(r'/(.*)/.*', r'\1', path)
-                longname = re.sub(rf'/{shortname}/([^_]*)_.*', r'\1', path)
+
+                # Extract platform names from mapfile.csv paths.
+                #   /NHM-EX/NehalemEX_core_V3.json -> NHM-EX, NehalemEX
+                #   /ADL/alderlake_uncore_v1.15.json -> ADL, alderlake
+                #   /TGL/events/tigerlake_core.json -> TGL, tigerlake
+                #   /WSM-EP-SP/events/WestmereEP-SP_core.json -> WSM-EP-SP, WestmereEP-SP
+                platform_pattern = r'/([a-zA-Z-]*)/(?:events/)?([a-zA-Z-]*)'
+                search_results = re.search(platform_pattern, path)
+                if not search_results:
+                    raise Exception('Failed extracting platform names from {} using {}'.format(path, platform_pattern))
+                shortname, longname = search_results.groups()
+
                 url = base_url + path
 
                 # Bug fixes:

--- a/download_and_gen.py
+++ b/download_and_gen.py
@@ -351,7 +351,9 @@ def hermetic_download(url: str, metrics_url: str, outdir: str):
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument('--url', default='https://download.01.org/perfmon')
+    ap.add_argument(
+        '--url',
+        default='https://raw.githubusercontent.com/intel/perfmon/main')
     ap.add_argument(
         '--metrics-url',
         default='https://raw.githubusercontent.com/intel/perfmon-metrics/main')


### PR DESCRIPTION
This pull request updates the default website used to fetch perfmon event files. Since https://github.com/intel/perfmon contains both events and metrics, the regex here was updated to handle the extra directory. Additional steps/details are also tracked in the parent issue at https://github.com/intel/perfmon/issues/17 .